### PR TITLE
Add End Grow button, cleanup code, add config for api url

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,10 +33,14 @@ export default class App extends React.Component {
     constructor(props) {
         super(props);
 
+        global.apiUrl = `http://localhost:3000`;
+
         this.state = {
             currentUser: null
         };
     }
+
+
 
     componentDidMount() {
         authenticationService.currentUser.subscribe(x => this.setState({currentUser: x}));

--- a/src/GrowDetails/GrowDetails.jsx
+++ b/src/GrowDetails/GrowDetails.jsx
@@ -216,6 +216,11 @@ export default class GrowDetails extends React.Component {
         }
     }
 
+    handleEndGrow() {
+        growService.endGrowById(this.state.grow);
+        window.location = "/grows";
+    }
+
     render() {
         if (this.state.grow._id) {
             var isLightOn = this.currentTimeWithinRange();
@@ -248,6 +253,12 @@ export default class GrowDetails extends React.Component {
                                                 window.location = "/grows/" + this.props.match.params.growId + "/timeline"
                                             }}>
                                         Timeline
+                                    </button>
+                                    <button className="btn btn-danger p-2 mr-2"
+                                            onClick={() => {
+                                                this.handleEndGrow();
+                                            }}>
+                                        End Grow
                                     </button>
                                 </div>
                             </div>

--- a/src/GrowEdit/GrowEdit.jsx
+++ b/src/GrowEdit/GrowEdit.jsx
@@ -80,7 +80,9 @@ export default class GrowEdit extends React.Component {
             grow.name = this.state.currentName;
         }
 
-        if (this.state.selectedConfig && grow.config && this.state.selectedConfig._id !== grow.config._id) {
+        // check and make sure we have a config selected
+        // TODO: previous code was checking for previously set grow state.  Consider updating to prevent resaving of something that has no new information
+        if (this.state.selectedConfig && this.state.selectedConfig._id) {
             grow.config = this.state.selectedConfig;
         }
 
@@ -89,10 +91,9 @@ export default class GrowEdit extends React.Component {
 
         // TODO: Implement growth stages (derrived from config)
         grow.growStage = 'N/A';
-
         let bundle = {
             _id: grow._id,
-            configId: grow.config._id,
+            growConfigId: grow.config._id,
             name: grow.name,
             numPlants: grow.numPlants,
             growStage: grow.growStage

--- a/src/GrowList/GrowList.jsx
+++ b/src/GrowList/GrowList.jsx
@@ -3,6 +3,7 @@ import Carousel from "react-bootstrap/Carousel";
 import {growService} from '../_services/grow.service';
 import "./growList.css";
 import GrowListItem from './GrowListItem';
+import { growConfigService } from "../_services/grow.config.service";
 
 export default class GrowList extends React.Component {
     constructor(props) {
@@ -15,7 +16,12 @@ export default class GrowList extends React.Component {
     }
 
     componentDidMount() {
-        growService.getAll().then(grows => this.setState({grows}))
+        //-- get all grows, then join them with their config
+        growService.getAll()
+            //.then(grows => grows.map(grow => growConfigService
+            //    .getById(grow.growConfigId)
+            //    .then(config => grow.config = config)))
+            .then(grows => this.setState({grows}));
     }
 
     render() {

--- a/src/_services/authentication.service.js
+++ b/src/_services/authentication.service.js
@@ -19,7 +19,7 @@ function register(username, email, password, confirmPassword) {
         body: JSON.stringify({ username, email, type: 0, password, confirmPassword })
     };
 
-    return fetch(`https://api.robogrow.io/register`, requestOptions)
+    return fetch(global.apiUrl + `/register`, requestOptions)
         .then(handleResponse)
         .then(user => {
             // store user details and jwt token in local storage to keep user logged in between page refreshes
@@ -37,7 +37,7 @@ function login(email, password) {
         body: JSON.stringify({ email, password })
     };
 
-    return fetch(`https://api.robogrow.io/authenticate`, requestOptions)
+    return fetch(global.apiUrl + `/authenticate`, requestOptions)
         .then(handleResponse)
         .then(user => {
             // store user details and jwt token in local storage to keep user logged in between page refreshes

--- a/src/_services/grow.config.service.js
+++ b/src/_services/grow.config.service.js
@@ -16,17 +16,17 @@ function create(config) {
         body: JSON.stringify(config)
     };
 
-    return fetch(`https://api.robogrow.io/configs/`, requestOptions).then(handleResponse);
+    return fetch(global.apiUrl + `/configs/`, requestOptions).then(handleResponse);
 }
 
 function getAll() {
     const requestOptions = { method: 'GET', headers: authHeader() };
-    return fetch(`https://api.robogrow.io/configs`, requestOptions).then(handleResponse);
+    return fetch(global.apiUrl + `/configs`, requestOptions).then(handleResponse);
 }
 
 function getById(_id) {
     const requestOptions = { method: 'GET', headers: authHeader() };
-    return fetch(`https://api.robogrow.io/configs/` + _id, requestOptions).then(handleResponse);
+    return fetch(global.apiUrl + `/configs/` + _id, requestOptions).then(handleResponse);
 }
 
 function updateById(config) {
@@ -36,7 +36,7 @@ function updateById(config) {
         body: JSON.stringify(config)
     };
 
-    return fetch(`https://api.robogrow.io/configs/` + config._id, requestOptions).then(handleResponse);
+    return fetch(global.apiUrl + `/configs/` + config._id, requestOptions).then(handleResponse);
 }
 
 function deleteConfig(id) {
@@ -45,5 +45,5 @@ function deleteConfig(id) {
         headers: authHeader()
     };
 
-    return fetch(`https://api.robogrow.io/configs/` + id, requestOptions).then(handleResponse);
+    return fetch(global.apiUrl + `/configs/` + id, requestOptions).then(handleResponse);
 }

--- a/src/_services/grow.service.js
+++ b/src/_services/grow.service.js
@@ -5,6 +5,7 @@ export const growService = {
     getAll,
     getById,
     updateById,
+    endGrowById,
     createNew,
     getTimelineEvents,
     createNewTimelineEvent,
@@ -14,7 +15,7 @@ export const growService = {
 
 function getAll() {
     const requestOptions = {method: 'GET', headers: authHeader()};
-    return fetch(`https://api.robogrow.io/grows`, requestOptions).then(handleResponse);
+    return fetch(global.apiUrl + `/grows`, requestOptions).then(handleResponse);
 }
 
 function getById(_id) {
@@ -24,7 +25,7 @@ function getById(_id) {
     console.log("heacers: " + JSON.stringify(tempHeaders));
 
     const requestOptions = {method: 'GET', headers: tempHeaders};
-    return fetch(`https://api.robogrow.io/grows/` + _id, requestOptions).then(handleResponse);
+    return fetch(global.apiUrl + `/grows/` + _id, requestOptions).then(handleResponse);
 }
 
 function updateById(grow) {
@@ -34,7 +35,17 @@ function updateById(grow) {
         body: JSON.stringify(grow)
     };
 
-    return fetch(`https://api.robogrow.io/grows/` + grow._id, requestOptions).then(handleResponse);
+    return fetch(global.apiUrl + `/grows/` + grow._id, requestOptions).then(handleResponse);
+}
+
+function endGrowById(grow) {
+    const requestOptions = {
+        method: 'PUT',
+        headers: authHeader(),
+        body: JSON.stringify(grow),
+    };
+
+    return fetch(global.apiUrl + `/grows/` + grow._id + `/end`, requestOptions).then(handleResponse);
 }
 
 function createNew(grow) {
@@ -44,12 +55,12 @@ function createNew(grow) {
         body: JSON.stringify(grow)
     };
 
-    return fetch(`https://api.robogrow.io/grows/`, requestOptions).then(handleResponse);
+    return fetch(global.apiUrl + `/grows/`, requestOptions).then(handleResponse);
 }
 
 function getTimelineEvents(_id) {
     const requestOptions = {method: 'GET', headers: authHeader()};
-    return fetch(`https://api.robogrow.io/grows/` + _id + `/timeline`, requestOptions).then(handleResponse);
+    return fetch(global.apiUrl + `/grows/` + _id + `/timeline`, requestOptions).then(handleResponse);
 }
 
 function createNewTimelineEvent(_id, event) {
@@ -59,7 +70,7 @@ function createNewTimelineEvent(_id, event) {
         body: JSON.stringify(event)
     };
 
-    return fetch(`https://api.robogrow.io/grows/` + _id + `/timeline`, requestOptions).then(handleResponse);
+    return fetch(global.apiUrl + `/grows/` + _id + `/timeline`, requestOptions).then(handleResponse);
 }
 
 function updateTimelineEvent(_id, event) {
@@ -69,7 +80,7 @@ function updateTimelineEvent(_id, event) {
         body: JSON.stringify(event)
     };
 
-    return fetch(`https://api.robogrow.io/grows/` + _id + `/timeline/` + event._id, requestOptions).then(handleResponse);
+    return fetch(global.apiUrl + `/grows/` + _id + `/timeline/` + event._id, requestOptions).then(handleResponse);
 }
 
 function deleteTimelineEvent(growId, eventId) {
@@ -78,5 +89,5 @@ function deleteTimelineEvent(growId, eventId) {
         headers: authHeader()
     };
 
-    return fetch(`https://api.robogrow.io/grows/` + growId + `/timeline/` + eventId, requestOptions).then(handleResponse);
+    return fetch(global.apiUrl + `/grows/` + growId + `/timeline/` + eventId, requestOptions).then(handleResponse);
 }


### PR DESCRIPTION
Added the End Grow button to Grow Details.  This will route you back to the grows list once you set a grow inactive.

Also cleaned up some saving/editing of grows, specifically a check that prevented any save from reaching the API.

Also updated App.js to use a global that can change which API you're using (dev/prod).  We REALLY REALLY REALLY should consider updating this to be an ENV variable.