### PR TITLE
Fix updateConfiguration to properly send data to api

### DIFF
--- a/src/GrowConfigs/GrowConfigEdit/GrowConfigEdit.jsx
+++ b/src/GrowConfigs/GrowConfigEdit/GrowConfigEdit.jsx
@@ -40,17 +40,22 @@ export default class GrowConfigDetails extends React.Component {
     }
 
     updateConfiguration(obj) {
+        let config = this.state.config;
         if (obj.type === 'temperature') {
+            config.tempLow = obj.value.min;
+            config.tempHigh = obj.value.max;
             this.setState({
-                tempValue: obj.value
+                config: config,
             });
         } else {
+            config.humidityLow = obj.value.min;
+            config.humidityHigh = obj.value.max;
             this.setState({
-                humidityValue: obj.value
+                config: config,
             });
         }
 
-        growConfigService.updateById(this.state.config)
+        growConfigService.updateById(config);
     }
 
     updateRelaySchedules(schedule) {


### PR DESCRIPTION
Fixes the issue where data set through onRelease was not getting bound and sent back to the api.

Also, we should consider doing some research into how setState() works, as technically we maybe not be able to read the modified state directly after setting.